### PR TITLE
Improve markdown styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
 	"dependencies": {
 		"@astrojs/cloudflare": "^12.5.3",
 		"astro": "^5.8.0",
-		"@astrojs/tailwind": "^5.0.0",
-		"tailwindcss": "^3.0.0"
+                "@astrojs/tailwind": "^5.0.0",
+                "tailwindcss": "^3.0.0",
+                "@tailwindcss/typography": "^0.5.9"
 	},
 	"devDependencies": {
 		"@types/node": "^22.15.21",

--- a/src/layouts/DiaryLayout.astro
+++ b/src/layouts/DiaryLayout.astro
@@ -18,7 +18,7 @@ const { title } = Astro.props;
       <a href="/diary" class="text-orange-400 hover:text-orange-300">Diary</a>
     </nav>
   </header>
-  <main>
+  <main class="prose prose-invert mx-auto">
     <slot />
   </main>
 </body>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,8 +1,10 @@
 /** @type {import('tailwindcss').Config} */
+import typography from '@tailwindcss/typography';
+
 export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
     extend: {},
   },
-  plugins: [],
-} 
+  plugins: [typography],
+}


### PR DESCRIPTION
## Summary
- install tailwind typography plugin
- style diary layout markdown with Tailwind `prose`

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845af8befac832abbcf9ff61042460f